### PR TITLE
Add support for secret, server-side only config

### DIFF
--- a/lib/generators/project.js
+++ b/lib/generators/project.js
@@ -53,6 +53,10 @@ Generator.create({
   this.writeDir('server');
   this.writeDir('server/lib');
   this.writeDir('server/collections');
+  this.writeDir('server/config');
+  this.writeDir('server/config/development');
+  this.writeDir('server/config/staging');
+  this.writeDir('server/config/production');
   this.writeDir('server/controllers');
   this.writeDir('server/db');
   this.writeDir('server/methods');


### PR DESCRIPTION
Having a server-side only configuration directory is important for storing things like API keys, setting up roles, and populating Accounts. Maybe the root config directory could be split up between client and server but for now, I just added a server-side config directory with subdirectories for storing secret info for dev, staging, and prod environments.
