### PR TITLE
Fix for issue #10 "em g:scaffold resource fails"

### DIFF
--- a/lib/generators/project.js
+++ b/lib/generators/project.js
@@ -53,7 +53,6 @@ Generator.create({
   this.writeDir('server');
   this.writeDir('server/lib');
   this.writeDir('server/collections');
-  this.writeDir('server/config');
   this.writeDir('server/controllers');
   this.writeDir('server/db');
   this.writeDir('server/methods');


### PR DESCRIPTION
Fixed the regex used. I made the semicolon optional with the ? operator since not everyone uses them. Cleaned up the server-side config stuff from my previous pull request in this branch, as well.
