### PR TITLE
add .gitkeep to all directories by default

### DIFF
--- a/lib/command.js
+++ b/lib/command.js
@@ -298,6 +298,7 @@ Command.prototype = {
         return false;
 
       this.logSuccess('created ' + p);
+      this.writeFile(path.join(dir, '.gitkeep'), '', opts);
       return true;
     } catch (e) {
       this.logError("Error creating directory " + p + ". " + String(e));


### PR DESCRIPTION
Simple change for #13 which allows that all directories can easily be committed into a git repository.
I might want to add that `.gitkeep` has no special meaning to git. It's just a convention for a file to tell git "keep that directory".
