### PR TITLE
Include/exclude css resources with with --cssresource and --no-cssresource flags

### DIFF
--- a/bin/em.js
+++ b/bin/em.js
@@ -7,6 +7,5 @@ var args = argv._;
 var em = require('../lib/em.js');
 
 Fiber(function () {
-   console.log('args 1: ', args, 'argv', argv);
   em.run(args, argv);
 }).run();

--- a/lib/command.js
+++ b/lib/command.js
@@ -60,39 +60,49 @@ var Command = module.exports = function (opts, handler) {
 Command.prototype = {
   constructor: Command,
 
-  getPassedInCss: function(exts) {
-    var ext;
+  getPassedInCssType: function(exts) {
+    var ext = { type: '.css' };
     switch (true) {
       case exts.css:
-        ext = ['.css'];
         break;
       case exts.less:
-        ext = ['.less'];
+        ext.alternate = '.less';
         break;
       case exts.scss:
-        ext = ['.scss'];
+      case exts.sass:
+        ext.alternate = '.scss';
         break;
-      default:
-        ext = ['.css'];
+      case exts.styl:
+      case exts.stylus:
+        ext.alternate = '.styl';
+        break;
     }
     return ext;
   },
 
   getCssOrPreprocessor: function() {
-    return this.hasPackage('less') ? '.less' : this.hasPackage('scss') ? '.scss' : '.css';
+    if (this.hasPackage('less'))
+      return {type: '.css', alternate: '.less'};
+    else if (this.hasPackage('scss'))
+      return {type: '.css', alternate: '.scss'}
+    else if (this.hasPackage('stylus'))
+      return {type: '.css', alternate: '.styl'}
+    else
+      return {type: '.css'}
   },
 
-  fileExtensions: function(opts) { // need to make sure we only return on of: css, scss, or less
+  fileExtensions: function(opts) {
     var cssExts = [],
-    addExts = ['.html', '.js'],
-    optExts = _.pick(opts, ['css', 'less', 'scss']);
+    addExts = [{type: '.html'}, {type: '.js'}],
+    optExts = _.pick(opts, ['css', 'less', 'scss', 'sass', 'styl', 'stylus']);
 
     if (_.contains(optExts, false))
       return addExts;
     else if (_.contains(optExts, true))
-      return addExts.concat(this.getPassedInCss(optExts));
+      return addExts.concat(this.getPassedInCssType(optExts));
     else
       return addExts.concat(this.getCssOrPreprocessor(optExts));
+
   },
 
   match: function (nameOrAlias) {
@@ -129,8 +139,7 @@ Command.prototype = {
         return res;
     }
   },
-  // NOTE: self._handler is then called and passed in
-  // this, args, and opts
+
   run: function (args, opts) {
     var self = this;
     args = args || [];

--- a/lib/em.js
+++ b/lib/em.js
@@ -14,9 +14,7 @@ var requireAll = function (relpath) {
     require(path.join(dirpath, file));
   });
 };
-// NOTE: 1. a new command object is created
-// this inherits its methods from command.js
-// run is called first
+
 em = new Command({
   name: 'em',
   description: 'A command line scaffolding tool for Meteor applications.',
@@ -45,12 +43,12 @@ em = new Command({
 
     console.log(table.toString());
   }
-}, function (args, opts) { // NOTE: this is first to get called: args and opts passed in from em.run()
-                           // args:  [ 'g:view', 'getsome8' ] opts: { _: [ 'g:view', 'getsome8' ] }
-  var command = args[0]; // g:view
+}, function (args, opts) {
+
+  var command = args[0];
   if (!command)
     throw new Command.UsageError;
-  this.runSubCommand(command, args.slice(1), opts); // example args.slice(1) = name of view
+  this.runSubCommand(command, args.slice(1), opts); 
 });
 
 em.Command = Command;

--- a/lib/generators/view.js
+++ b/lib/generators/view.js
@@ -18,34 +18,25 @@ Generator.create({
   var dir = opts.dir || '';
   var dirpath = path.join('client/views/' + dir, dirname);
 
-  var alternateExtensions = {
-    '.css': this.hasPackage('less') ? '.less' : '.css'
-  };
-
-  console.log('args: ', args);
-  console.log('opts: ', opts);
-
   var templatesForExt = opts.templates || {};
-  console.log('templatesForExt: ', templatesForExt);
 
   try {
    var fileExtensions = this.fileExtensions(opts);
-   console.log(fileExtensions);
 
-  //  _.each(fileExtensions, function (ext) {
-  //    var newExt = alternateExtensions[ext] || ext;
-  //    var filename = dirname + newExt;
-  //    var tmplName = templatesForExt[ext] || 'view';
-  //    filepath = path.join( dirpath, filename );
-   //
-  //    var tmplContent = self.template('client/views/' + tmplName + ext, {
-  //      filepath: filepath,
-  //      filename: filename,
-  //      name: self.classCase(name)
-  //    });
+   _.each(fileExtensions, function (ext) {
+     var newExt = _.has(ext, 'alternate') ? ext.alternate : ext.type;
+     var filename = dirname + newExt;
+     var tmplName = templatesForExt[ext.type] || 'view';
+     filepath = path.join( dirpath, filename );
 
-  //    self.writeFile(filepath, tmplContent);
-  //  });
+     var tmplContent = self.template('client/views/' + tmplName + ext.type, {
+       filepath: filepath,
+       filename: filename,
+       name: self.classCase(name)
+     });
+
+     self.writeFile(filepath, tmplContent);
+   });
   } catch (e) {
     this.logError("Error creating view: " + String(e));
     return 1;


### PR DESCRIPTION
Partially fixes issue: #6. I need to go back through and make the added methods more generic so that they can handle not just `--cssresource` and `--no-cssresource`, but any resource for that matter. In other words, it might be nice to be able to use coffee instead of js: `--coffee`.
