### PR TITLE
Fix jade filepath rendering

### DIFF
--- a/lib/templates/client/views/view.html.ejs
+++ b/lib/templates/client/views/view.html.ejs
@@ -4,5 +4,5 @@
 </template>
 <% } else { %>
 template(name='<%= name %>')
-  <%= filepath %>
+  | <%= filepath %>
 <% } %>


### PR DESCRIPTION
Current code outputs the following when using jade template

``` jade
template(name='TodosDetail')
  filepath
```

This is not a valid jade due to filepath not being an html tag
