### PR TITLE
Upgrade dependency to fibers v. 1.0.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "underscore": "1.3.3",
     "cli-table": "0.3.0",
     "ejs": "0.8.5",
-    "fibers": "1.0.1",
+    "fibers": "1.0.5",
     "single-line-log": "0.4.1"
   },
   "bin": {


### PR DESCRIPTION
Simple upgrade of dependencies in order to avoid errors like that in #3 , which is indeed related to fibers.

Got myself in trouble after a node version upgrade to 0.12.0, and trying after ```npm install -g meteor-em```.

Upgrading the dependency, it sorts by default the ```npm install -g meteor-em``` issue, too.

```
$ node -v
v0.12.0
$ npm -v
2.5.1
```