### PR TITLE
Move .git directory to project root

### DIFF
--- a/lib/commands/migrate.js
+++ b/lib/commands/migrate.js
@@ -70,6 +70,8 @@ Command.create({
   fs.renameSync('app/config', './config');
   fs.renameSync('app/lib/router/routes.js', 'app/lib/routes.js');
   fs.rmdirSync('app/lib/router');
+  if (this.isDirectory('app/.git'))
+    fs.renameSync('app/.git', './.git');
 
   Iron.findCommand('init').invoke([], initOptions);
 


### PR DESCRIPTION
This is related to the discussion #102 . During migration, we move back ```.git``` folder from ```app/.git``` to ```./.git```. Note the check for the existence of ```app/.git``` folder, too (in case the user doesn't use git/uses other version control system).