### PR TITLE
[Enhancement] CSS Names and HTML templates

### DIFF
--- a/lib/generators/template.js
+++ b/lib/generators/template.js
@@ -25,7 +25,7 @@ Generator.create({
   this.template(
     'template/template.html',
     pathToTemplate + '.html',
-    context
+    _.extend({}, context, { className: this.cssCase(opts.resourceName) })
   );
 
   this.template(

--- a/lib/templates/template/template.css
+++ b/lib/templates/template/template.css
@@ -1,2 +1,2 @@
-.<%= className %> {
+.<%= className %>-template {
 }

--- a/lib/templates/template/template.css
+++ b/lib/templates/template/template.css
@@ -1,2 +1,2 @@
-.<%= className %>-template {
+.template-<%= className %> {
 }

--- a/lib/templates/template/template.css.less
+++ b/lib/templates/template/template.css.less
@@ -1,4 +1,4 @@
 /* less stylesheet */
 
-.<%= className %> {
+.<%= className %>-template {
 }

--- a/lib/templates/template/template.css.less
+++ b/lib/templates/template/template.css.less
@@ -1,4 +1,4 @@
 /* less stylesheet */
 
-.<%= className %>-template {
+.template-<%= className %> {
 }

--- a/lib/templates/template/template.css.scss
+++ b/lib/templates/template/template.css.scss
@@ -1,2 +1,2 @@
-.<%= className %> {
+.<%= className %>-template {
 }

--- a/lib/templates/template/template.css.scss
+++ b/lib/templates/template/template.css.scss
@@ -1,2 +1,2 @@
-.<%= className %>-template {
+.template-<%= className %> {
 }

--- a/lib/templates/template/template.css.styl
+++ b/lib/templates/template/template.css.styl
@@ -1,2 +1,2 @@
-.<%= className %> {
+.<%= className %>-template {
 }

--- a/lib/templates/template/template.css.styl
+++ b/lib/templates/template/template.css.styl
@@ -1,2 +1,2 @@
-.<%= className %>-template {
+.template-<%= className %> {
 }

--- a/lib/templates/template/template.html
+++ b/lib/templates/template/template.html
@@ -1,3 +1,5 @@
 <template name="<%= name %>">
-  <h1>Find me in <%= myPath %></h1>
+  <div class="<%= className %>-template">
+    <h1>Find me in <%= myPath %></h1>
+  </div>
 </template>

--- a/lib/templates/template/template.html
+++ b/lib/templates/template/template.html
@@ -1,5 +1,5 @@
 <template name="<%= name %>">
-  <div class="<%= className %>-template">
+  <div class="template-<%= className %>">
     <h1>Find me in <%= myPath %></h1>
   </div>
 </template>


### PR DESCRIPTION
Heya, wanted to hear what you think about this? 

+ Added `-template` to the CSS class names to make the name more unique and so easier to distinguish it is a "template style".
+ Added a div to the html template that reference the style specifically

Example if you want to specifically style `item` div in a certain the `Menu` template you can do:
```
.menu-template .item {
  /* style */
}
```

I always did this manually to each template when I was using EM so now that I saw Iron generate css class names I figured it would be great to take it all the way. What do you think?

TODO:
+ I didn't update the jade file (not sure of the syntax)
