### PR TITLE
Added CoffeeScript routes to migration command

### DIFF
--- a/lib/commands/migrate.js
+++ b/lib/commands/migrate.js
@@ -47,7 +47,7 @@ Command.create({
         initOptions['skip-template-js'] = true;
 
       if (oldConfig.view.css.create === false)
-        initOptions['skip-template-css'] = true; 
+        initOptions['skip-template-css'] = true;
     } catch(e) {
       // assume the json file was bad but don't do
       // anything about it
@@ -76,6 +76,8 @@ Command.create({
   if (this.isDirectory('app/client/views')) fs.renameSync('app/client/views', 'app/client/templates');
   if (this.isDirectory('app/config')) fs.renameSync('app/config', './config');
   if (this.isFile('app/lib/router/routes.js')) fs.renameSync('app/lib/router/routes.js', 'app/lib/routes.js');
+  if (this.isFile('app/lib/router/routes.coffee')) fs.renameSync('app/lib/router/routes.coffee', 'app/lib/routes.coffee');
+  //FIXME: Check if router is empty (user may created other files in router dir)
   if (this.isDirectory('app/lib/router')) fs.rmdirSync('app/lib/router');
 
   Iron.findCommand('init').invoke([], initOptions);


### PR DESCRIPTION
It resolves bug #117 when using `iron migrate` from an `em` project using `CoffeeScript` failed.
