### PR TITLE
Add debug instruction.

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,12 @@ $ iron run --env staging
 
 This will use the config files in `config/staging` instead.
 
+### Debug Your Application 
+
+```sh
+$ iron debug
+```
+
 ### Build Your Application
 
 ```sh


### PR DESCRIPTION
Suggestion: advertise the debug capabilities. Users won't need to go through the trouble of figuring out how node-inspector works with Iron if they know it installs/runs it for them. Doesn't have to be too verbose since the terminal instance speaks for itself. Closes #122.