### PR TITLE
Update hooks for Meteor 1.0.4

### DIFF
--- a/lib/templates/template/template.js
+++ b/lib/templates/template/template.js
@@ -13,11 +13,11 @@ Template.<%= name %>.helpers({
 /*****************************************************************************/
 /* <%= name %>: Lifecycle Hooks */
 /*****************************************************************************/
-Template.<%= name %>.created = function () {
-};
+Template.<%= name %>.onCreated(function () {
+});
 
-Template.<%= name %>.rendered = function () {
-};
+Template.<%= name %>.onRendered(function () {
+});
 
-Template.<%= name %>.destroyed = function () {
-};
+Template.<%= name %>.onDestroyed(function () {
+});


### PR DESCRIPTION
The `created`, `rendered`, and `destroyed` hooks are now changed to `onCreated`, `onRendered` and `onDestroyed`