### PR TITLE
relay stderr when invoking meteor command

### DIFF
--- a/lib/tools/meteor.js
+++ b/lib/tools/meteor.js
@@ -166,6 +166,10 @@ module.exports.invokeMeteorCommand = function invokeMeteorCommand(cmd, args) {
     console.log(data.toString());
   });
 
+  child.stderr.on('data', function stderr(data) {
+    console.error(data.toString());
+  });
+
   _.each(['SIGINT', 'SIGHUP', 'SIGTERM'], function (sig) {
     process.once(sig, function () {
       process.kill(child.pid, sig);


### PR DESCRIPTION
When using meteor from a checkout, meteor prints the following message to stderr:

```
=> Running Meteor from a checkout -- overrides project version (Meteor 1.0.5)
```

But without the proposed change, this message gets lost, and it becomes confusing to the user whether they are really running the version of meteor that they are expecting to.

Thanks for considering!