### PR TITLE
cssCase now replaces all underscore characters

### DIFF
--- a/lib/tools/strings.js
+++ b/lib/tools/strings.js
@@ -67,5 +67,5 @@ module.exports.fileCase = function fileCase(str) {
  * Given FooBar, fooBar, or foo_bar returns foo-bar
  */
 module.exports.cssCase = function cssCase(str) {
-  return this.fileCase(str).replace('_', '-');
+  return this.fileCase(str).replace(/_/g, '-');
 };


### PR DESCRIPTION
Generating multi-word templates, e.g. `iron generate template how_it_works` would cause the pre-filled css class to be `.how-it_works` because the cssCase function would only replace the first underscore with a dash. This fix uses a regex to replace all underscores with dashes.