### PR TITLE
Fix HomeController to be found

### DIFF
--- a/lib/templates/app/lib/controllers/home_controller.js.coffee
+++ b/lib/templates/app/lib/controllers/home_controller.js.coffee
@@ -1,4 +1,4 @@
-HomeController = RouteController.extend(
+@HomeController = RouteController.extend(
   layoutTemplate: 'MasterLayout'
   subscriptions: ->
   action: ->


### PR DESCRIPTION
This controller - on scaffolded applications using coffeescript - produces an empty white page with the following message `Error: RouteController 'HomeController' is not defined.`