### PR TITLE
Rewrite destination path for engine for publish and routes

### DIFF
--- a/lib/generators/publish.js
+++ b/lib/generators/publish.js
@@ -15,7 +15,7 @@ Generator.create({
     collection: this.classCase(opts.resourceName)
   };
 
-  var destpath = this.pathFromApp('server/publish.js');
+  var destpath = this.rewriteDestinationPathForEngine(this.pathFromApp('server/publish.js'));
   var content = this.templateContent('publish/publish.js', context);
   this.injectAtEndOfFile(destpath, '\n' + content);
 });

--- a/lib/generators/route.js
+++ b/lib/generators/route.js
@@ -23,7 +23,7 @@ var RouteGenerator = Generator.create({
     where: opts.where === 'server' ? 'server' : 'client'
   };
 
-  var destpath = this.pathFromApp('lib/routes.js');
+  var destpath = this.rewriteDestinationPathForEngine(this.pathFromApp('lib/routes.js'));
   var content = this.templateContent('route/route.js', context);
   this.injectAtEndOfFile(destpath, '\n' + content);
 

--- a/lib/templates/app/lib/controllers/home_controller.js.coffee
+++ b/lib/templates/app/lib/controllers/home_controller.js.coffee
@@ -1,4 +1,4 @@
-HomeController = RouteController.extend(
+@HomeController = RouteController.extend(
   layoutTemplate: 'MasterLayout'
   subscriptions: ->
   action: ->


### PR DESCRIPTION
1. When setting the js engine to coffeescript scaffolding breaks slightly when updating publish and routes as it doesn't rewrite the destination path as expected.

2. Expose HomeController to the global scope by prefixing it with @ in templates/app/lib/controllers/home_controller.js.coffee