### PR TITLE
Fix invalid JSON syntax on config.json

### DIFF
--- a/lib/templates/project/.iron/config.json
+++ b/lib/templates/project/.iron/config.json
@@ -14,6 +14,6 @@
   "route": {
     "controller": <%= config.route.controller %>,
     "template": <%= config.route.template %>
-  },
-
+  }
+  
 }


### PR DESCRIPTION
Extra comma produces de command 'iron create <name>' to stop due to invalid token error